### PR TITLE
ran dos2unix script on all bash files and built container with compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,4 @@ COPY entrypoint.sh entrypoint.sh
 RUN chmod +x ./SqlCmdStartup.sh
 
 
-ENTRYPOINT /bin/bash ./entrypoint.sh
-CMD /bin/bash ./SqlCmdStartup.sh 
+CMD /bin/bash ./entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ COPY entrypoint.sh entrypoint.sh
 RUN chmod +x ./SqlCmdStartup.sh
 
 
-CMD /bin/bash ./entrypoint.sh
+ENTRYPOINT /bin/bash ./entrypoint.sh
+CMD /bin/bash ./SqlCmdStartup.sh 

--- a/SqlCmdStartup.sh
+++ b/SqlCmdStartup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #wait for the SQL Server to come up
 sleep 30s
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+
+services:  
+  sql:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    # command: python /app/manage.py runserver 0.0.0.0:8000
+    
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,5 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    # command: python /app/manage.py runserver 0.0.0.0:8000
     
   

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,2 @@
 #start SQL Server, start the script to create the DB and data
-/opt/mssql/bin/sqlservr.sh & ./SqlCmdStartup.sh 
+/opt/mssql/bin/sqlservr.sh 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,2 @@
 #start SQL Server, start the script to create the DB and data
-/opt/mssql/bin/sqlservr.sh 
+./SqlCmdStartup.sh & /opt/mssql/bin/sqlservr.sh  


### PR DESCRIPTION
the changes I made was that since i was building the container from windows, using git bash, i ran the `dos2unix` script. on all `.sh` files I also built the container with docker-compose but it should just be fine with the default docker build process.
```dos2unix SqlCmdStart.sh```
```dos2unix entrypoint.sh```

```docker bulld -t <image_name> .` # with docker```
or
```docker-compose run sql # with docker-compose```