### PR TITLE
Make entrypoint.sh wait on the SQL Server process

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,6 @@
 #start SQL Server, start the script to create the DB and data
-/opt/mssql/bin/sqlservr.sh & ./SqlCmdStartup.sh 
+/opt/mssql/bin/sqlservr.sh &
+SQLSERVER_PID=$!
+
+./SqlCmdStartup.sh # run the startup command while SQL Server is in the background...
+wait $SQLSERVER_PID # ...and then once it's done, wait on the SQL Server process


### PR DESCRIPTION
Try this to make the entry point script wait for the SQL Server process instead of exiting after your startup script is finished.